### PR TITLE
Build on Ubuntu18 with make command.

### DIFF
--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -270,7 +270,7 @@ bool transactions_flow_test(std::string& working_folder,
     misc_utils::sleep_no_w(DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN*1000);//wait two blocks before sync on another wallet on another daemon
   }
 
-  uint64_t money_2 = w2.balance(0);
+  uint64_t money_2 = uint64_t(w2.balance(0));
   if(money_2 == transfered_money)
   {
     MGINFO_GREEN("-----------------------FINISHING TRANSACTIONS FLOW TEST OK-----------------------");

--- a/tests/hash-target.cpp
+++ b/tests/hash-target.cpp
@@ -34,6 +34,7 @@
 #include <limits>
 #include "misc_log_ex.h"
 #include "crypto/hash.h"
+#include "cryptonote_config.h"
 #include "cryptonote_basic/difficulty.h"
 
 using namespace std;

--- a/tests/unit_tests/difficulty.cpp
+++ b/tests/unit_tests/difficulty.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gtest/gtest.h"
+#include "cryptonote_config.h"
 #include "cryptonote_basic/difficulty.h"
 
 static cryptonote::difficulty_type MKDIFF(uint64_t high, uint64_t low)


### PR DESCRIPTION
On Ubuntu18, the compiler would report some warning when building.
g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
After the following change, I can build the project on Ubuntu 18 with make command. 